### PR TITLE
feat: Add robots.txt with story directory restrictions

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /stories/
+
+User-agent: *
+Allow: /


### PR DESCRIPTION
### TL;DR

Added robots.txt file to control web crawler access

### What changed?

Created a new robots.txt file in the public directory that:
- Blocks crawlers from accessing the `/stories/` directory
- Allows crawlers to access all other paths

### How to test?

1. Navigate to `/robots.txt` in your browser
2. Verify the file contains the correct directives:
   - `Disallow: /stories/`
   - `Allow: /`

### Why make this change?

To implement proper crawler control for search engines and other web robots, ensuring sensitive or private content in the stories directory remains protected while allowing the rest of the site to be indexed.