### PR TITLE
feat: add in sticky position on stories pages

### DIFF
--- a/src/pages/stories/[...slug].astro
+++ b/src/pages/stories/[...slug].astro
@@ -21,15 +21,15 @@ const { Content } = await entry.render();
 
 ---
 <Main>
-  <div class="md:col-span-8 md:col-start-3 col-span-10 col-start-2">
+  <div class="md:col-span-8 md:col-start-3 col-span-10 col-start-2 pb-10">
     <h1 class="title text-4xl text-center font-sans font-bold my-4">{entry.data.title} </h1>
     <h2 class="chapter-title text-2xl text-center my-3 text-zinc-300">
       {entry.data.chapter === 0 ? 'Prologue': `Chapter ${entry.data.chapter}`}
     </h2>
     <Content />
   </div>
-  <div class="hidden md:block md:col-span-2 sticky top-12 ">
-    <ol class="mt-9 ml-4">
+  <div class="hidden md:block md:col-span-2">
+    <ol class="mt-9 ml-4 sticky top-20">
       {storiesCollection.map(chapter => (
         <li class={chapter.slug === entry.slug ? 'font-bold' : undefined}>
           <a href={`/stories/${chapter.slug}`}>{chapter.data.chapter === 0 ? 'Prologue': `Chapter ${chapter.data.chapter}`}</a>

--- a/src/pages/stories/index.astro
+++ b/src/pages/stories/index.astro
@@ -1,6 +1,36 @@
 ---
 import MainLayout from "../../layouts/main.astro";
-// import { collections } from '../../content/config'; 
+import { getCollection } from "astro:content";
+const stories = await getCollection('stories', e => import.meta.env.NODE_ENV !== 'production' || !e.data.draft)
+  .then(st => st.sort((a, b) => a.data.chapter - b.data.chapter));
+
+type Story = Awaited<ReturnType<typeof getCollection<'stories'>>>[number];
+
+type MappedStory = {
+  title: string;
+  chapters: number;
+  tags: Set<string>;
+    slug: string;
+}
+
+type StoryGroup = Record<string, MappedStory>;
+
+const groupedStories = stories.reduce((acc, story) => {
+  if(!acc[story.data.title]) acc[story.data.title] = {
+    title: story.data.title,
+    chapters: 0,
+    tags: new Set(),
+    slug: story.slug,
+  }
+
+  acc[story.data.title].chapters +=1;
+  for(const tag of story.data.tags) {
+    acc[story.data.title].tags.add(tag);
+  }
+  
+  return acc;
+}, {} as Record<string, MappedStory>);
+
 ---
 
 <MainLayout>
@@ -10,11 +40,30 @@ import MainLayout from "../../layouts/main.astro";
       The stories that I&apos;ve written over the years are generally a mix of random things
     </p>
     <main>
-      <article class="border p-3 rounded-md">
-        <header>
-          <h2 class="title text-2xl font-black">House Stray</h2>
-        </header>
-      </article>
+      {
+        Object.entries(groupedStories)
+          .map(([title, storyItem]) => (
+            <article class="border p-3 rounded-md">
+              <a href={`/stories/${storyItem.slug}`}>
+                <header class="flex justify-between items-center">
+                  <h2 class="title text-2xl font-black">
+                    {title}
+                    <small>
+                      &ndash; {storyItem.chapters} Chapter(s)
+                    </small>
+                  </h2>
+                  <div class="flex gap-3">
+                    {
+                      Array.from(storyItem.tags).map(tag=> (
+                        <span class="text-zinc-700 bg-blue-300 text-sm p-2 rounded-md">{tag}</span>
+                      ))
+                    }
+                  </div>
+                </header>
+              </a>
+            </article>
+          ))
+      }
     </main>
   </section>
   <div class="col-start-11 col-span-2" id="side-info">


### PR DESCRIPTION
### TL;DR
Added story listing functionality and improved chapter navigation styling

### What changed?
- Created a dynamic story listing page that displays all stories with their chapter counts and tags
- Added links to navigate directly to stories from the listing page
- Improved chapter navigation sidebar styling with better sticky positioning
- Added padding to the bottom of story content for better readability
- Stories are now sorted by chapter number
- Added draft filtering for production environment

### How to test?
1. Add multiple stories with different chapters and tags
2. Navigate to the stories index page to verify the listing displays correctly
3. Click on story titles to ensure navigation works
4. Verify chapter navigation sidebar remains visible while scrolling
5. Check that draft stories are hidden in production but visible in development

### Why make this change?
To provide a better user experience by making it easier to discover and navigate between stories while maintaining a clean, organized layout. The improved navigation and story listing helps readers find and track their progress through multi-chapter stories more effectively.