### PR TITLE
feat(house-stray): Chapter 1

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,7 @@ const storiesCollection = defineCollection({
     tags: z.array(z.string()),
     chapter: z.number().min(0),
     draft: z.boolean().default(true),
+    chapterTitle: z.string().optional(),
   }),
   // @ts-ignore I know this is hacky I don't care
   name: 'Stories',

--- a/src/content/stories/house-stray/chapter-1.md
+++ b/src/content/stories/house-stray/chapter-1.md
@@ -7,6 +7,115 @@ tags:
   - fantasy
 ---
 
-Testing testing. What the actual hell is happening.
+<blockquote>
+We thought we knew how things worked. In all the studies, all the papers,
+all the research since, we don't even know where it is we didn't actually know
+anything. Lifetimes of effort, thrown into the trashbins of history in a single
+set of skills. At one point I was named the foremost expert on multiple areas of
+study in both science and magic. Now I find myself just as much a layman as the
+fishmonger at the docks. We don't know what he became... Yet.
+</blockquote>
 
-I like tacos
+The bells for the afternoon break at the local school rang. Around noon the
+school released its students to eat, either at their own houses or in the shared
+cafeteria of the school. The cafeteria in this school was once renowned in the
+area as one of the best, but since the decline of the ports the neighborhood
+around the school had fallen to disrepair. Some buildings were empty, broken
+dreams the only inhabitants of their molded or fire-stained walls. Many were in
+a state that ran somewhere between unpleasant and uninhabitable. Most were
+livable, if you were okay with not having some of the more common comforts of a
+glorious city, like Volhabende had been.
+
+Most of the students shuffled out to their homes to eat lunch. Remy arrived back
+at his house looking worse for wear. He had clearly been in some kind of
+scuffle, but he was also getting to an age where he needed to figure out how to
+solve some issues without his mom's interference. Not that she could see him
+right now. Remy's mother was at work in a neighboring town during the day. Remy
+didn't know a lot about his father, neither Remy's mother or older brother would
+ever speak about him. He had a very vague memory of a man. The man was always a
+little dirty, and though he cut an imposing shadow in the doorway he always
+seemed likeable enough. He knew his father's last name though; Remy carried with
+him: Lorenth.
+
+Remy didn't bother looking through the kitchen, knowing well that there wasn't
+anything he could eat for lunch right now. Instead he rummaged for some
+antiseptic ointment his mother had gotten from a clinic about a year ago when
+his older brother hurt himself at work. Remy had a decent sized cut on his side
+and it stung any time he tried to turn or move his left arm too high up. If he
+was going to be able to focus through the rest of school today he couldn't let
+this distract him. He'd probably have his brother take a look at it when he saw
+him next, and he really hoped his brother didn't try to give him stitches again.
+The last time the stitches arguably hurt more than what had given him the gash.
+
+Finally, lifting some things out of a drawer Remy found it. Weird that it was
+kept under all of that other stuff, but his mom didn't exactly have a lot of
+time to keep things tidy around the house anymore. He squeezed some onto the
+skin just above his wound, took a deep breath in preparation for he knew was
+going to be a very unpleasant experience, and began to rub the ointment into the
+wound. For a brief moment Remy believed he was clearly over reacting as he
+couldn't feel any pain. Just when he exhaled, it hit him like a car and in his
+surprise he let out one word he was happy his mother didn't hear.
+
+"_Fuck!_" echoed through their small house, as he inhaled through his teeth in
+an effort to bear the pain.
+
+<hr />
+
+Thela sat in her school's cafeteria, waiting in line to grab one of the salads
+of assorted fruit. She was looking at one that had more of her favorite fruit
+than the others available, and desperately hoping no one else took it before she
+got there. She'd been so intent on the fruit salad that she missed what her
+friend Jordan was saying to her.
+
+"Uh huh", Thela said, eyes still focusing on the fruit salad she was hoping
+would still be available by the time she got up there.
+
+Jordan's smile dropped a bit. "I've told you about agreeing to things when
+you're off in the void," he said with a sigh.
+
+"What are you looking at over there? Is it that oven or," he craned his head
+around a bit, alternating between standing on his tip toes and being flat footed
+in an attempt to get a better view over the other kids' heads, "or is it--"
+Jordan cut himself off when he saw it.
+
+"Really?" He looked back at her, incredulous.
+
+Thela, finally snapping out of her focus, realized she'd made a mistake that she's
+made a thousand times already into a mistake she's made a thousand and one
+times. Her cheeks flushed a bit, but she tried to play it off. "Really, what?"
+she said, trying to sound joking.
+
+"No no, I want to hear you admit that you were ignoring me because you were
+staring desperately at a fruid salad that had more of your favorite fruit." He
+said while keeping pace with the line.
+
+Thela placed her hand on her chest in mock surprise and scoffed. "I would
+never!" she declared, just as Jordan's head swiveled to look at her in a mocking
+face, hand already to his chest.
+
+"One of these days El you're gonna agree to something binding when you're off
+wandering inside your own head and no one is going to be able to help you."
+Jordan said, reaching over and plucking the fruit salad from the bin used to
+keep it cold.
+
+Thela protested with a weak "hey" and tried to grab it from Jordan's hand, but
+he had placed it cleanly above his head. Him being a few inches taller meant
+that short of climbing Jordan, Thela's only real way of getting that from him
+was if he gave it to her. Still, she tried to pull his arm down to no avail. All
+the while, Jordan chuckled at her struggles.
+
+"What's the magic word?" Jordan said, smug in his clear victory.
+
+"You're an ass!" Thela said, giving up and turning to grab another one.
+
+"Eh, close enough," he said thumping the cup onto her tray and grabbing a
+different snack. "I'd rather have one of these marshmallows."
+
+Thela, goal now attained, focused back on Jordan. "So, what was it you were
+trying to tell me?"
+
+"Hmm? Oh, nothing important. Was asking if you'd looked at the work we're
+supposed to do for math."
+
+"No," Thela said, elongating out the word to drive home how little she wanted to
+even think about the work they needed to do for their math classes.

--- a/src/pages/stories/[...slug].astro
+++ b/src/pages/stories/[...slug].astro
@@ -24,12 +24,21 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 
 const readingTime = Math.ceil(entry.body.split(/\s+/).length / 250);
+
+function renderChapterName(entry: (typeof Astro.props)['entry']): string {
+  return entry.data.chapter !== 0
+    ? `Chapter ${entry.data.chapter}${
+        entry.data.chapterTitle ? `: ${entry.data.chapterTitle}` : ''
+      }`
+    : 'Prologue';
+}
 ---
 <Main>
-  <div class="lg:col-span-6 md:col-span-8 md:col-start-3 lg:col-start-4 col-span-12 px-6 md:px-0 pb-10">
+  <div class="lg:col-span-6 md:col-span-8 md:col-start-3 lg:col-start-4 col-span-12 px-6 md:px-0 pb-10 prose">
     <h1 class="title text-4xl text-center font-sans font-bold my-4">{entry.data.title} </h1>
-    <h2 class="chapter-title text-2xl text-center my-3 text-zinc-300">
+    <h2 class="chapter-title text-2xl text-center my-3 text-zinc-300 text-balance">
       {entry.data.chapter === 0 ? 'Prologue': `Chapter ${entry.data.chapter}`}
+      {entry.data.chapterTitle ? `: ${entry.data.chapterTitle}` : ''}
     </h2>
     <h3 class="text-center mb-6">
       <small>
@@ -42,7 +51,7 @@ const readingTime = Math.ceil(entry.body.split(/\s+/).length / 250);
     <ol class="mt-9 ml-4 sticky top-20">
       {storiesCollection.map(chapter => (
         <li class={chapter.id === entry.id? 'font-bold' : undefined}>
-          <a href={`/stories/${chapter.id}`}>{chapter.data.chapter === 0 ? 'Prologue': `Chapter ${chapter.data.chapter}`}</a>
+          <a href={`/stories/${chapter.id}`}>{renderChapterName(chapter)}</a>
         </li>
       ))}
     </ol>
@@ -58,5 +67,12 @@ const readingTime = Math.ceil(entry.body.split(/\s+/).length / 250);
     margin-top: theme('spacing.2');
     line-height: theme('spacing.6');
   }
-  
+  blockquote {
+    margin-left: calc(var(--spacing) * 6);
+    font-style: italic;
+    margin-bottom: calc(var(--spacing) * 6);
+    & em,i {
+      font-style: normal;
+    }
+  }
 </style>


### PR DESCRIPTION
### TL;DR

Added support for chapter titles in stories and enhanced the story content display with proper styling for blockquotes.

### What changed?

- Added an optional `chapterTitle` field to the stories collection schema
- Updated the story page to display chapter titles when available
- Implemented a `renderChapterName` function to consistently format chapter names across the UI
- Added styling for blockquotes in story content with proper margins and italic formatting
- Added substantial content to the first chapter of "House Stray" story
- Applied prose styling to the story content container for better typography

### How to test?

1. Navigate to the "House Stray" story to see the updated content with blockquotes
2. Verify that chapter titles display correctly in both the story header and chapter navigation
3. Check that the blockquote styling is applied correctly with proper margins and italic text
4. Ensure the prose styling improves readability of the story content

### Why make this change?

This change enhances the reading experience by providing more context through chapter titles and improving the visual presentation of story content. The blockquote styling allows for better separation of quoted text from the main narrative, while the added prose styling ensures consistent typography throughout the stories. These improvements make the reading experience more immersive and professional.