### PR TITLE
chore: Adds in package manager field to the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "astro": "^5.1.1",
     "tailwindcss": "^4.0.15",
     "typescript": "^5.5.4"
-  }
+  },
+  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a"
 }


### PR DESCRIPTION
### TL;DR
Added PNPM package manager specification to package.json

### What changed?
Added explicit PNPM package manager version 9.15.3 with SHA integrity hash to package.json

### How to test?
1. Delete node_modules and pnpm-lock.yaml
2. Run `pnpm install`
3. Verify installation completes successfully
4. Verify correct PNPM version (9.15.3) is being used

### Why make this change?
Locks the project to a specific PNPM version to ensure consistent package management across all development environments and prevent potential issues from version mismatches