### PR TITLE
feat: Add blogs to the website

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,6 +14,17 @@ const storiesCollection = defineCollection({
   name: 'Stories',
 });
 
+const blogCollection = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/blogs'}),
+  schema: z.object({
+    title: z.string(),
+    tags: z.array(z.string()),
+    draft: z.boolean().default(true)
+  }),
+  // @ts-ignore I know this is hacky I don't care
+  name: 'Blog',
+});
+
 const otherCollection = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/other'}),
   schema: z.object({
@@ -28,5 +39,6 @@ const otherCollection = defineCollection({
 
 export const collections = {
   stories: storiesCollection,
+  blog: blogCollection,
   other: otherCollection
 };

--- a/src/content/blogs/2025/02/15/145828.md
+++ b/src/content/blogs/2025/02/15/145828.md
@@ -1,0 +1,8 @@
+---
+title: First Blog Post
+tags:
+  - chatting
+draft: true
+---
+
+I am the blog

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,26 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection, render} from 'astro:content';
+import MainLayout from '../../layouts/main.astro';
+
+export async function getStaticPaths() {
+  const blogEntries = await getCollection('blog', (e) => {
+    return import.meta.env.NODE_ENV !== 'production' || !e.data.draft
+  });
+  return blogEntries.map(entry => ({
+    params: { slug: entry.id},
+    props:  { entry}
+  }));
+}
+
+const { entry } = Astro.props;
+
+const { Content } = await render(entry);
+
+---
+
+<MainLayout>
+  <div class="col-start-3 col-span-8">
+    <Content />
+  </div>
+</MainLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,25 @@
+---
+import { getCollection } from 'astro:content';
+import MainLayout from '../../layouts/main.astro';
+type Blog = Awaited<ReturnType<typeof getCollection<'blog'>>>[number];
+const blogs = await getCollection('blog', e => import.meta.env.NODE_ENV !== 'production' || !e.data.draft);
+---
+<MainLayout>
+  <div class="col-start-3 col-span-8 py-8">
+    <h1 class="text-4xl font-bold">
+      Blogs
+    </h1>
+    <p>
+      Occasionally I write about things that aren't really a story,
+      but they're not very short so I'll just make them into a blog post.
+    </p>
+    {blogs.map(blog => (
+      <article class="my-4">
+        <a href={`/blog/${blog.id}`}>
+          {blog.data.title}
+        </a>
+        
+      </article>
+    ))}
+  </div>
+</MainLayout>

--- a/src/pages/stories/[...slug].astro
+++ b/src/pages/stories/[...slug].astro
@@ -3,8 +3,8 @@ import { getCollection, render } from "astro:content";
 import Main from "../../layouts/main.astro";
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection("stories", (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft);
-  return blogEntries.map((entry) => ({
+  const storyEntries = await getCollection("stories", (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft);
+  return storyEntries.map((entry) => ({
     params: { slug: entry.id },
     props: { entry },
   }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "strict": true
+  },
   "include": ["./astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
### TL;DR

Added a new blog section to the website with content collection support and routing.

### What changed?

- Created a new blog collection schema in content.config.ts
- Added blog post routing with [slug].astro
- Implemented a blog index page
- Added a sample blog post
- Updated TypeScript configuration to enforce strict mode
- Fixed variable naming in stories route for clarity

### How to test?

1. Run the development server
2. Navigate to `/blog` to see the blog index
3. Click on the sample blog post to verify routing works
4. Verify draft posts only show in development environment
5. Verify strict TypeScript checking is working

### Why make this change?

To provide a dedicated space for longer-form content that doesn't fit the "story" format, allowing for more diverse content types on the website.