### PR TITLE
feat: Add other section for writings that are poems or other non-story, non-blog posts

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,7 +2,7 @@
 
 @theme {
   --color-text-token: light-dark(var(--color-zinc-900), var(--color-zinc-100));
-  --color-background-token: light-dark(var(--color-slate-100), var(--color-slate-900));
+  --color-background-token: light-dark(var(--color-slate-100), var(--color-zinc-900));
 }
 
 :root[data-theme="light"] {
@@ -20,12 +20,21 @@
 html,body {
   background-color: var(--color-background-token);
   color: var(--color-text-token);
+  font-family: var(--font-sans);
 }
 
 @layer base {
   h1, h2, h3, h4, h5, h6 {
     line-height: 1.25em;
     margin-block-end: 0.25em;
+    > small {
+      margin-inline-start: --spacing(4);
+      color: 
+        light-dark(
+          hsl(from currentColor h s calc(l + 30)),
+          hsl(from currentColor h s calc(l - 20))
+        );
+    }
   }
 
   h1 {
@@ -36,5 +45,25 @@ html,body {
   h2 {
     font-size: var(--text-xl);
     font-weight: var(--font-weight-extrabold);
+  }
+
+  h3 {
+    font-size: var(--text-lg);
+    font-weight: var(--font-weight-bold);
+  }
+
+  h4 {
+    font-size: var(--text-md);
+    font-weight: var(--font-weight-semibold);
+    text-decoration: underline;
+  }
+
+  .lead {
+    font-size: 1.25em;
+  }
+
+  a:link,
+  a {
+    color: light-dark(var(--color-sky-700), var(--color-sky-400));
   }
 }

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -13,15 +13,21 @@ const { class: className } = Astro.props;
     <div class="flex items-center justify-center">
       <a href="/stories">Stories</a>
     </div>
+    <div class="flex items-center justify-center">
+      <a href="/other">Other writings</a>
+    </div>
   </div>
   
 </nav>
 
 <style>
+  a,a:link {
+    color: white;
+  }
   a:hover {
     text-decoration: underline;
   }
   a.active {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 </style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,6 +14,19 @@ const storiesCollection = defineCollection({
   name: 'Stories',
 });
 
+const otherCollection = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/other'}),
+  schema: z.object({
+    author: z.string(),
+    title: z.string(),
+    tags: z.array(z.string()),
+    draft: z.boolean().default(true)
+  }),
+  // @ts-ignore I know this is hacky I don't care
+  name: 'Others',
+});
+
 export const collections = {
   stories: storiesCollection,
+  other: otherCollection
 };

--- a/src/content/other/sadness.md
+++ b/src/content/other/sadness.md
@@ -1,0 +1,18 @@
+---
+author: Jim Burbridge
+title: Sadness among the memories
+tags:
+  - emotions
+draft: false
+---
+
+
+I am a knot in nothingness
+
+fraying reality at its seems
+
+Under my own weight will I break
+
+and my moment be no more
+
+I am the sadness, waiting to become null.

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -33,6 +33,14 @@ const { title = '' } = Astro.props;
     grid-template-columns: repeat(12, 1fr);  
     grid-template-rows: 70px 1fr minmax(100px, max-content);
     min-height: 100dvh;
+    container-name: main;
+    container-type: inline-size;
+  }
+
+  @media screen and (max-width: var(--breakpoint-sm)) {
+    .layout {
+      background-color: orange;
+    }
   }
   
 </style>

--- a/src/pages/other/[...slug].astro
+++ b/src/pages/other/[...slug].astro
@@ -1,0 +1,44 @@
+---
+import { getCollection, render } from 'astro:content';
+import Main from "../../layouts/main.astro";
+
+export async function getStaticPaths() {
+  const entries = await getCollection('other', (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft);
+  return entries.map(entry => ({
+    params: { 
+      slug: entry.id,
+    },
+    props: { entry }
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+
+const others = await getCollection('other', story => !story.data.draft && story.id !== entry.id);
+
+---
+
+<Main>
+  <div class="wrapper @lg/main:col-span-8 @lg/main:col-start-3 mt-8 grid grid-cols-subgrid">
+    <div class="@lg/main:col-span-6 p-4">
+      {
+        entry.data.title && 
+        <h2 class="mb-4">{entry.data.title} <small> by {entry.data.author}</small></h2>
+      }
+
+
+      <Content />
+    </div>
+    <aside class="@lg/main:col-span-2 p-4">
+      <h4>Other stories</h4>
+      {
+        others.length === 0 && (
+          <p>
+            No other stories available at the moment
+          </p>
+        )
+      }
+    </aside>
+  </div>
+</Main>

--- a/src/pages/other/index.astro
+++ b/src/pages/other/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from "astro:content";
+import Main from "../../layouts/main.astro";
+
+const stories = await getCollection("other", (f) => {
+  return import.meta.env.NODE_ENV !== "production" || !f.data.draft;
+});
+
+const storyMaps = stories.reduce((all, cur) => {
+  for(const tag of cur.data.tags) {
+    let mapped = all.get(tag);
+    if (mapped === undefined) {
+      mapped = [];
+      all.set(tag, mapped);
+    }
+    mapped.push(cur);
+  }
+  return all;
+}, new Map<string, typeof stories>());
+
+---
+<Main title="Hello">
+  <div class="@lg/main:col-span-6 @lg/main:col-start-3 space-y-4">
+    <h1 class="mt-4 col-span-12">Other stories</h1>
+    <p class="lead">
+      Sometimes I write things that aren't exactly blogs or stories. This is
+      where those pieces will live.
+    </p>
+    {
+      stories.length === 0 && (
+        <div>No other pieces exist at this moment in time</div>
+      )
+    }
+    {
+      stories.length > 0 && (
+        <div class="space-y-5">
+          {stories.map((story) => (
+            <h3 class="bg-slate-800 p-4 rounded-md">
+              <a href={`/other/${story.id}`}>
+                {story.data.title}
+              </a>
+            </h3>
+          ))}
+        </div>
+      )
+    }
+  </div>
+  <aside class="@lg/main:col-span-2 @lg/main:pl-8">
+    <h3 class="mt-8 mb-4">
+      By Tags
+    </h3>
+
+    <div class="space-y-4 flex flex-wrap gap-2">
+      {
+        Array.from(storyMaps.keys())
+          .map(k => (
+            <div class="pill px-2 py-1 border rounded capitalize">
+              <a href={`?tag=${k}`}>
+                {k}
+              </a>
+            </div>
+          ))
+      }
+    </div>
+  </aside>
+</Main>


### PR DESCRIPTION
# Add support for "Other writings" section

This PR adds a new section to the site for content that doesn't fit into the existing categories. Key changes include:

- Added a new "Other writings" navigation link in the navbar
- Created a new content collection for these writings with appropriate schema
- Added sample content with a poem "Sadness among the memories"
- Implemented pages to display the collection and individual entries
- Enhanced styling with:
  - Updated link colors
  - Added h3 and lead paragraph styles
  - Changed dark mode background color from slate-900 to zinc-900
  - Added container queries for responsive layouts