### PR TITLE
fix(mobile): Others/poems layout had some weirdness

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "astro": "^5.1.1",
     "tailwindcss": "^4.0.15",
     "typescript": "^5.5.4"
-  }
+  },
+  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a"
 }

--- a/src/pages/other/[...slug].astro
+++ b/src/pages/other/[...slug].astro
@@ -20,8 +20,8 @@ const others = await getCollection('other', story => !story.data.draft && story.
 ---
 
 <Main>
-  <div class="wrapper col-span-6 @lg/main:col-span-8 @lg/main:col-start-3 mt-8 grid grid-cols-subgrid">
-    <div class="@lg/main:col-span-6 p-4">
+  <div class="wrapper col-span-12 @lg/main:col-span-8 @lg/main:col-start-3 mt-8 grid grid-cols-subgrid">
+    <div class="@lg/main:col-span-6 col-span-12 p-4">
       {
         entry.data.title && 
         <h2 class="mb-4">{entry.data.title} <small> by {entry.data.author}</small></h2>


### PR DESCRIPTION
### TL;DR

Added PNPM package manager specification and fixed responsive layout issues on the "other" pages.

### What changed?

- Added `packageManager` field to `package.json` specifying PNPM version 9.15.3 with SHA hash
- Fixed responsive layout in `[...slug].astro` by:
  - Changing the wrapper div from `col-span-6` to `col-span-12` for better mobile display
  - Adding `col-span-12` to the inner div to ensure proper full-width display on mobile devices

### How to test?

1. Verify the project uses PNPM 9.15.3 when installing dependencies
2. Check the "other" pages on mobile and desktop viewports to ensure proper responsive behavior
3. Confirm the content spans the full width on mobile and maintains the correct layout on larger screens

### Why make this change?

The PNPM specification ensures consistent package management across development environments. The layout fixes address responsive design issues on the "other" pages where content wasn't properly spanning the full width on mobile devices, improving the overall user experience across different screen sizes.