### PR TITLE
chore: Add biome for linting and formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: BiomeJS Lint Check
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'  # Specify the Node.js version your project uses
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run BiomeJS
+        run: pnpm biome

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": ["astro-build.astro-vscode"],
-  "unwantedRecommendations": []
+	"recommendations": ["astro-build.astro-vscode"],
+	"unwantedRecommendations": []
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "command": "./node_modules/.bin/astro dev",
-      "name": "Development server",
-      "request": "launch",
-      "type": "node-terminal"
-    }
-  ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"command": "./node_modules/.bin/astro dev",
+			"name": "Development server",
+			"request": "launch",
+			"type": "node-terminal"
+		}
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,11 @@
 {
-  "lnf.aliases": {
-    "$/": "${workspaceRoot}/",
-    "$pages/": "${workspaceRoot}/src/pages/",
-    "$components/": "${workspaceRoot}/src/components/"
-  }
+	"lnf.aliases": {
+		"$/": "${workspaceRoot}/",
+		"$pages/": "${workspaceRoot}/src/pages/",
+		"$components/": "${workspaceRoot}/src/components/"
+	},
+	"[astro]": {
+		"editor.defaultFormatter": "biomejs.biome",
+		"editor.formatOnSave": true
+	}
 }

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,10 +7,10 @@ export default defineConfig({
   env: {
     schema: {
       NODE_ENV: envField.string({ context: 'server', access: 'secret' }),
-    }
+    },
   },
 
   vite: {
-    plugins: [tailwindcss()]
-  }
+    plugins: [tailwindcss()],
+  },
 });

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"indentStyle": "space",
+			"quoteStyle": "single"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,22 +1,26 @@
 {
-  "name": "burbridge-lol",
-  "type": "module",
-  "version": "0.0.1",
-  "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro check && astro build",
-    "preview": "astro preview",
-    "astro": "astro"
-  },
-  "dependencies": {
-    "@astrojs/check": "^0.9.4",
-    "@astrojs/db": "^0.14.5",
-    "@astrojs/tailwind": "^5.1.4",
-    "@tailwindcss/vite": "^4.0.15",
-    "astro": "^5.1.1",
-    "tailwindcss": "^4.0.15",
-    "typescript": "^5.5.4"
-  },
-  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a"
+	"name": "burbridge-lol",
+	"type": "module",
+	"version": "0.0.1",
+	"scripts": {
+		"dev": "astro dev",
+		"start": "astro dev",
+		"build": "astro check && astro build",
+		"preview": "astro preview",
+		"astro": "astro",
+		"format": "biome format"
+	},
+	"dependencies": {
+		"@astrojs/check": "^0.9.4",
+		"@astrojs/db": "^0.14.5",
+		"@astrojs/tailwind": "^5.1.4",
+		"@tailwindcss/vite": "^4.0.15",
+		"astro": "^5.1.1",
+		"tailwindcss": "^4.0.15",
+		"typescript": "^5.5.4"
+	},
+	"packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a",
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,10 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
 
 packages:
 
@@ -98,6 +102,59 @@ packages:
   '@babel/types@7.26.3':
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -2578,6 +2635,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:

--- a/public/main.css
+++ b/public/main.css
@@ -1,3 +1,3 @@
 .full {
-  grid-column: 1 / span 12;
+	grid-column: 1 / span 12;
 }

--- a/scripts/add-blog.js
+++ b/scripts/add-blog.js
@@ -1,18 +1,18 @@
 #!/usr/env/bin node
 import { writeFile, mkdir } from 'node:fs/promises';
-import { dirname} from 'node:path'
+import { dirname } from 'node:path';
 
 const today = new Date();
 
 /**
- * 
- * @param {Intl.DateTimeFormatPart[]} parts 
+ *
+ * @param {Intl.DateTimeFormatPart[]} parts
  */
 function partsToObject(parts) {
   /** @type {Record<'year' | 'month' | 'day' | 'hour' | 'minute' | 'second', string>} */
   const obj = {};
-  for(const part of parts) {
-    if(part.type !== 'literal') {
+  for (const part of parts) {
+    if (part.type !== 'literal') {
       obj[part.type] = part.value;
     }
   }
@@ -21,15 +21,15 @@ function partsToObject(parts) {
 
 const formatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
-  'month':'2-digit',
+  month: '2-digit',
   day: '2-digit',
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
-  hour12: false
+  hour12: false,
 });
 
-const obj = partsToObject(formatter.formatToParts(today))
+const obj = partsToObject(formatter.formatToParts(today));
 
 console.log('Creating new blog post...');
 
@@ -43,4 +43,4 @@ draft: true
 
 console.log(`Writing file to ${fileName}`);
 await mkdir(dirname(fileName), { recursive: true });
-await writeFile(fileName, baseContent, { flag: 'w+'});
+await writeFile(fileName, baseContent, { flag: 'w+' });

--- a/src/app.css
+++ b/src/app.css
@@ -1,81 +1,101 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @theme {
-  --color-text-token: light-dark(var(--color-zinc-900), var(--color-zinc-100));
-  --color-background-token: light-dark(var(--color-slate-200), var(--color-zinc-900));
-  --color-primary-token: light-dark(var(--color-emerald-600), var(--color-emerald-400));
-  --color-on-primary-token: light-dark(var(--color-zinc-900), var(--color-zinc-900));
-  --color-surface-token: light-dark(var(--color-zinc-200), var(--color-zinc-800));
-  --color-on-surface-token: light-dark(var(--color-zinc-900), var(--color-zinc-100));
+	--color-text-token: light-dark(var(--color-zinc-900), var(--color-zinc-100));
+	--color-background-token: light-dark(
+		var(--color-slate-200),
+		var(--color-zinc-900)
+	);
+	--color-primary-token: light-dark(
+		var(--color-emerald-600),
+		var(--color-emerald-400)
+	);
+	--color-on-primary-token: light-dark(
+		var(--color-zinc-900),
+		var(--color-zinc-900)
+	);
+	--color-surface-token: light-dark(
+		var(--color-zinc-200),
+		var(--color-zinc-800)
+	);
+	--color-on-surface-token: light-dark(
+		var(--color-zinc-900),
+		var(--color-zinc-100)
+	);
 }
 
 :root[data-theme="light"] {
-  color-scheme: light;
+	color-scheme: light;
 }
 
 :root[data-theme="dark"] {
-  color-scheme: dark;
+	color-scheme: dark;
 }
 
 :root {
-  color-scheme: light dark;
+	color-scheme: light dark;
 }
 
-html,body {
-  background-color: var(--color-background-token);
-  color: var(--color-text-token);
-  font-family: var(--font-sans);
+html,
+body {
+	background-color: var(--color-background-token);
+	color: var(--color-text-token);
+	font-family: var(--font-sans);
 }
 
 @media print {
-  body > .layout > nav,
-  body > .layout > footer {
-    display: none;
-  }
+	body > .layout > nav,
+	body > .layout > footer {
+		display: none;
+	}
 }
 
 @layer base {
-  h1, h2, h3, h4, h5, h6 {
-    line-height: 1.25em;
-    margin-block-end: 0.25em;
-    text-wrap: balance;
-    > small {
-      margin-inline-start: --spacing(4);
-      color: 
-        light-dark(
-          hsl(from currentColor h s calc(l + 30)),
-          hsl(from currentColor h s calc(l - 20))
-        );
-    }
-  }
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		line-height: 1.25em;
+		margin-block-end: 0.25em;
+		text-wrap: balance;
+		> small {
+			margin-inline-start: --spacing(4);
+			color: light-dark(
+				hsl(from currentColor h s calc(l + 30)),
+				hsl(from currentColor h s calc(l - 20))
+			);
+		}
+	}
 
-  h1 {
-    font-size: var(--text-3xl);
-    font-weight: var(--font-weight-black);
-  }
+	h1 {
+		font-size: var(--text-3xl);
+		font-weight: var(--font-weight-black);
+	}
 
-  h2 {
-    font-size: var(--text-xl);
-    font-weight: var(--font-weight-extrabold);
-  }
+	h2 {
+		font-size: var(--text-xl);
+		font-weight: var(--font-weight-extrabold);
+	}
 
-  h3 {
-    font-size: var(--text-lg);
-    font-weight: var(--font-weight-bold);
-  }
+	h3 {
+		font-size: var(--text-lg);
+		font-weight: var(--font-weight-bold);
+	}
 
-  h4 {
-    font-size: var(--text-md);
-    font-weight: var(--font-weight-semibold);
-    text-decoration: underline;
-  }
+	h4 {
+		font-size: var(--text-md);
+		font-weight: var(--font-weight-semibold);
+		text-decoration: underline;
+	}
 
-  .lead {
-    font-size: 1.25em;
-  }
+	.lead {
+		font-size: 1.25em;
+	}
 
-  a:link,
-  a {
-    color: light-dark(var(--color-sky-700), var(--color-sky-400));
-  }
+	a:link,
+	a {
+		color: light-dark(var(--color-sky-700), var(--color-sky-400));
+	}
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,25 +2,25 @@ import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
 const storiesCollection = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/stories'}),
+  loader: glob({ pattern: '**/*.md', base: './src/content/stories' }),
   schema: z.object({
     author: z.string(),
     title: z.string(),
     tags: z.array(z.string()),
     chapter: z.number().min(0),
-    draft: z.boolean().default(true)
+    draft: z.boolean().default(true),
   }),
   // @ts-ignore I know this is hacky I don't care
   name: 'Stories',
 });
 
 const otherCollection = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './src/content/other'}),
+  loader: glob({ pattern: '**/*.md', base: './src/content/other' }),
   schema: z.object({
     author: z.string(),
     title: z.string(),
     tags: z.array(z.string()),
-    draft: z.boolean().default(true)
+    draft: z.boolean().default(true),
   }),
   // @ts-ignore I know this is hacky I don't care
   name: 'Others',
@@ -28,5 +28,5 @@ const otherCollection = defineCollection({
 
 export const collections = {
   stories: storiesCollection,
-  other: otherCollection
+  other: otherCollection,
 };

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -1,6 +1,6 @@
 ---
-import Navbar from "../components/navbar/navbar.astro";
-import Footer from "../components/footer/footer.astro";
+import Navbar from '../components/navbar/navbar.astro';
+import Footer from '../components/footer/footer.astro';
 import '../app.css';
 const { title = '' } = Astro.props;
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import MainLayout from "../layouts/main.astro";
+import MainLayout from '../layouts/main.astro';
 ---
 <MainLayout>
   <section class="@lg/main:col-span-8 @lg/main:col-start-3 p-4" id="main-info">

--- a/src/pages/other/[...slug].astro
+++ b/src/pages/other/[...slug].astro
@@ -1,24 +1,29 @@
 ---
 import { getCollection, render } from 'astro:content';
-import Main from "../../layouts/main.astro";
+import Main from '../../layouts/main.astro';
 
 export async function getStaticPaths() {
-  const entries = await getCollection('other', (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft);
-  return entries.map(entry => ({
-    params: { 
+  const entries = await getCollection(
+    'other',
+    (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft,
+  );
+  return entries.map((entry) => ({
+    params: {
       slug: entry.id,
     },
-    props: { entry }
+    props: { entry },
   }));
 }
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 
-const others = await getCollection('other', story => !story.data.draft && story.id !== entry.id);
+const others = await getCollection(
+  'other',
+  (story) => !story.data.draft && story.id !== entry.id,
+);
 
 const readingTime = Math.ceil(entry.body.split(/\s+/).length / 250);
-
 ---
 
 <Main>

--- a/src/pages/other/index.astro
+++ b/src/pages/other/index.astro
@@ -1,13 +1,13 @@
 ---
-import { getCollection } from "astro:content";
-import Main from "../../layouts/main.astro";
+import { getCollection } from 'astro:content';
+import Main from '../../layouts/main.astro';
 
-const stories = await getCollection("other", (f) => {
-  return import.meta.env.NODE_ENV !== "production" || !f.data.draft;
+const stories = await getCollection('other', (f) => {
+  return import.meta.env.NODE_ENV !== 'production' || !f.data.draft;
 });
 
 const storyMaps = stories.reduce((all, cur) => {
-  for(const tag of cur.data.tags) {
+  for (const tag of cur.data.tags) {
     let mapped = all.get(tag);
     if (mapped === undefined) {
       mapped = [];
@@ -17,7 +17,6 @@ const storyMaps = stories.reduce((all, cur) => {
   }
   return all;
 }, new Map<string, typeof stories>());
-
 ---
 <Main title="Other Pieces">
   <div class="p-4 col-span-12 @lg/main:col-span-6 @lg/main:col-start-3 space-y-4">

--- a/src/pages/stories/[...slug].astro
+++ b/src/pages/stories/[...slug].astro
@@ -1,9 +1,12 @@
 ---
-import { getCollection, render } from "astro:content";
-import Main from "../../layouts/main.astro";
+import { getCollection, render } from 'astro:content';
+import Main from '../../layouts/main.astro';
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection("stories", (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft);
+  const blogEntries = await getCollection(
+    'stories',
+    (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft,
+  );
   return blogEntries.map((entry) => ({
     params: { slug: entry.id },
     props: { entry },
@@ -11,17 +14,16 @@ export async function getStaticPaths() {
 }
 
 const storiesCollection = await getCollection('stories', (e) => {
-  return import.meta.env.NODE_ENV !== 'production' || !e.data.draft
+  return import.meta.env.NODE_ENV !== 'production' || !e.data.draft;
 });
 
 // Sort the items by chapter
-storiesCollection.sort((a, b) => a.data.chapter - b.data.chapter)
+storiesCollection.sort((a, b) => a.data.chapter - b.data.chapter);
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 
-const readingTime = Math.ceil(entry.body.split(/\s+/).length /250);
-
+const readingTime = Math.ceil(entry.body.split(/\s+/).length / 250);
 ---
 <Main>
   <div class="lg:col-span-6 md:col-span-8 md:col-start-3 lg:col-start-4 col-span-12 px-6 md:px-0 pb-10">

--- a/src/pages/stories/index.astro
+++ b/src/pages/stories/index.astro
@@ -1,8 +1,10 @@
 ---
-import MainLayout from "../../layouts/main.astro";
-import { getCollection } from "astro:content";
-const stories = await getCollection('stories', e => import.meta.env.NODE_ENV !== 'production' || !e.data.draft)
-  .then(st => st.sort((a, b) => a.data.chapter - b.data.chapter));
+import MainLayout from '../../layouts/main.astro';
+import { getCollection } from 'astro:content';
+const stories = await getCollection(
+  'stories',
+  (e) => import.meta.env.NODE_ENV !== 'production' || !e.data.draft,
+).then((st) => st.sort((a, b) => a.data.chapter - b.data.chapter));
 
 type Story = Awaited<ReturnType<typeof getCollection<'stories'>>>[number];
 
@@ -10,27 +12,30 @@ type MappedStory = {
   title: string;
   chapters: number;
   tags: Set<string>;
-    slug: string;
-}
+  slug: string;
+};
 
 type StoryGroup = Record<string, MappedStory>;
 
-const groupedStories = stories.reduce((acc, story) => {
-  if(!acc[story.data.title]) acc[story.data.title] = {
-    title: story.data.title,
-    chapters: 0,
-    tags: new Set(),
-    slug: story.id,
-  }
+const groupedStories = stories.reduce(
+  (acc, story) => {
+    if (!acc[story.data.title])
+      acc[story.data.title] = {
+        title: story.data.title,
+        chapters: 0,
+        tags: new Set(),
+        slug: story.id,
+      };
 
-  acc[story.data.title].chapters +=1;
-  for(const tag of story.data.tags) {
-    acc[story.data.title].tags.add(tag);
-  }
-  
-  return acc;
-}, {} as Record<string, MappedStory>);
+    acc[story.data.title].chapters += 1;
+    for (const tag of story.data.tags) {
+      acc[story.data.title].tags.add(tag);
+    }
 
+    return acc;
+  },
+  {} as Record<string, MappedStory>,
+);
 ---
 
 <MainLayout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/base",
-  "include": ["./astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+	"extends": "astro/tsconfigs/base",
+	"include": ["./astro/types.d.ts", "**/*"],
+	"exclude": ["dist"]
 }


### PR DESCRIPTION
### TL;DR

Added BiomeJS for code formatting and linting with GitHub Actions integration.

### What changed?

- Added BiomeJS configuration in `biome.json` with formatting and linting rules
- Created a GitHub Actions workflow in `.github/workflows/lint.yml` to run BiomeJS checks on PRs
- Added BiomeJS as a dev dependency and a `format` script in package.json
- Configured VS Code settings to use BiomeJS as the default formatter for Astro files
- Formatted all existing files according to BiomeJS rules (consistent indentation, spacing, etc.)

### How to test?

1. Run `pnpm install` to install the new BiomeJS dependency
2. Try the formatter with `pnpm format` to verify it works correctly
3. Make changes to an Astro file in VS Code and save to see auto-formatting in action
4. Create a PR to verify the GitHub Actions workflow runs properly

### Why make this change?

Adding BiomeJS provides consistent code formatting and linting across the project, which improves code quality and readability. The GitHub Actions integration ensures that all PRs adhere to the same code style standards, reducing the need for style-related code review comments and making the codebase more maintainable.