### PR TITLE
feat: Adds in posthog and cookie banner

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
 	"[astro]": {
 		"editor.defaultFormatter": "biomejs.biome",
 		"editor.formatOnSave": true
-	}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"build": "astro check && astro build",
 		"preview": "astro preview",
 		"astro": "astro",
-		"format": "biome format"
+		"format": "biome format",
+    "new:blog": "deno run --allow-write --allow-read scripts/add-blog.ts"
 	},
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",

--- a/scripts/add-blog.ts
+++ b/scripts/add-blog.ts
@@ -1,16 +1,18 @@
-#!/usr/env/bin node
+#!/usr/env/bin -S deno run --allow-write
 import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 const today = new Date();
 
+type DatePartObject = Record<'year' | 'month' | 'day' | 'hour' | 'minute' | 'second', string>;
+
 /**
  *
  * @param {Intl.DateTimeFormatPart[]} parts
  */
-function partsToObject(parts) {
-  /** @type {Record<'year' | 'month' | 'day' | 'hour' | 'minute' | 'second', string>} */
-  const obj = {};
+function partsToObject(parts): DatePartObject {
+  /** @type {} */
+  const obj = {} as DatePartObject;
   for (const part of parts) {
     if (part.type !== 'literal') {
       obj[part.type] = part.value;

--- a/src/app.css
+++ b/src/app.css
@@ -90,12 +90,18 @@ body {
 		text-decoration: underline;
 	}
 
+  hr {
+    margin-block-start: --spacing(8);
+    margin-block-end: --spacing(8);
+  }
+
 	.lead {
 		font-size: 1.25em;
 	}
 
-	a:link,
-	a {
-		color: light-dark(var(--color-sky-700), var(--color-sky-400));
-	}
+  a:link,
+  a {
+    color: light-dark(var(--color-sky-700), var(--color-sky-400));
+  }
+
 }

--- a/src/components/cookies/cookie.astro
+++ b/src/components/cookies/cookie.astro
@@ -1,0 +1,37 @@
+
+<div id="cookie-banner" class="banner fixed p-4 rounded-lg left-8 right-8 bg-surface-token text-on-surface-token flex justify-between bottom-8 hidden">
+  <p>I use tooling to track errors on the page. It does not track any user information or other variety of identifiable information.</p>
+  <div>
+    <button type="button" class="btn px-3 py-2 rounded-full bg-primary-token text-on-primary-token">
+      Ok
+    </button>
+  </div>
+</div>
+
+<script is:inline>
+  document.addEventListener('DOMContentLoaded', () => {
+    const bannerEl = document.querySelector('#cookie-banner');
+    if(!bannerEl) return;
+
+    if(!document.cookie.includes('cookieConsent=')) {
+      bannerEl.classList.remove('hidden');
+      bannerEl.classList.add('in');
+      bannerEl.querySelector('[type=button]').addEventListener('click', () => {
+        document.cookie = 'cookieConsent='+ new Date().toISOString()+';expires='+new Date('2026-01-01');
+        bannerEl.classList.replace('flex', 'hidden')
+      });
+    } 
+
+  });
+</script>
+
+<style>
+  .banner {
+    transition: translate 500ms ease-in;
+    translate: 0 100%;
+  }
+
+  .banner.in {
+    translate: 0 0%;
+  }
+</style>

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,0 +1,52 @@
+<script is:inline>
+  !(function (t, e) {
+    var o, n, p, r;
+    e.__SV ||
+      ((window.posthog = e),
+      (e._i = []),
+      (e.init = function (i, s, a) {
+        function g(t, e) {
+          var o = e.split(".");
+          2 == o.length && ((t = t[o[0]]), (e = o[1])),
+            (t[e] = function () {
+              t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            });
+        }
+        ((p = t.createElement("script")).type = "text/javascript"),
+          (p.crossOrigin = "anonymous"),
+          (p.async = !0),
+          (p.src = s.api_host + "/static/array.js"),
+          (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(
+            p,
+            r
+          );
+        var u = e;
+        for (
+          void 0 !== a ? (u = e[a] = []) : (a = "posthog"),
+            u.people = u.people || [],
+            u.toString = function (t) {
+              var e = "posthog";
+              return (
+                "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e
+              );
+            },
+            u.people.toString = function () {
+              return u.toString(1) + ".people (stub)";
+            },
+            o =
+              "capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(
+                " "
+              ),
+            n = 0;
+          n < o.length;
+          n++
+        )
+          g(u, o[n]);
+        e._i.push([i, s, a]);
+      }),
+      (e.__SV = 1));
+  })(document, window.posthog || []);
+  posthog.init("phc_HaLqMjTX6V0XcDNz0w1fpHvdXDg2y0I7BdhkKLsE6Ai", {
+    api_host: "https://us.i.posthog.com",
+  });
+</script>

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -1,7 +1,10 @@
 ---
 import Navbar from '../components/navbar/navbar.astro';
 import Footer from '../components/footer/footer.astro';
+import Posthog from '../components/posthog.astro';
+
 import '../app.css';
+import Cookie from '../components/cookies/cookie.astro';
 const { title = '' } = Astro.props;
 ---
 
@@ -15,6 +18,7 @@ const { title = '' } = Astro.props;
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>Burbridge {title ? `- ${title}` : ''}</title>
+    <Posthog />
   </head>
   <body class="dark:bg-zinc-800 dark:text-zinc-100">
     <div class="layout">
@@ -24,13 +28,14 @@ const { title = '' } = Astro.props;
       </div>
       <Footer class="bg-black col-start-1 col-span-12 -row-end-1"/>
     </div>
+    <Cookie />
   </body>
 </html>
 
 <style>
   .layout {
     display: grid;
-    grid-template-columns: repeat(12, 1fr);  
+    grid-template-columns: repeat(12, minmax(1px, 1fr));
     grid-template-rows: 70px 1fr minmax(100px, max-content);
     min-height: 100dvh;
     container-name: main;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,62 @@
 ---
 import MainLayout from '../layouts/main.astro';
 ---
+
 <MainLayout>
-  <section class="@lg/main:col-span-8 @lg/main:col-start-3 p-4" id="main-info">
-    <h1 class="title text-4xl text-center font-black mb-3 mt-4">Welcome</h1>
+  <section
+    class="@lg/main:col-span-8 @lg/main:col-start-3 p-4 col-span-12"
+    id="main-info"
+  >
+    <h1 class="title text-4xl text-center font-black mb-3 mt-4 text-primary-token">Welcome</h1>
+    <p class="lead">
+      Welcome to my personal website. I write stories from time to time and I
+      figured this will be the best place to put them all.
+    </p>
+
+    <p class="lead">In general I write 3 different kinds of stories:</p>
+    <dl>
+      <dt>Stories</dt>
+      <dd>
+        These are longer running things that I write down when the mood strikes
+        me. I tend to have these thought out pretty far ahead, I just have issue
+        writing them down.
+      </dd>
+
+      <dt>Blogs</dt>
+      <dd>
+        Sometimes you just have to dump your brain out about a topic. This could
+        be something like a family update, or other stuff that doesn't really
+        belong on my professional site.
+      </dd>
+
+      <dt>Other</dt>
+      <dd>
+        I frequently have small things that I come to me. They aren't a story,
+        but they're not really a blog-level brain dump. Often times I suppose
+        these could be called &quot;poetry&quot; but they never feel like poems
+        to me (though perhaps my 6th grade English teacher would disagree)
+      </dd>
+    </dl>
     <p>
-      Welcome to my personal website. I write stories from time to time and I figured
-      this will be the best place to put them all. 
+      You can check out these things in the navbar up top. My discord is linked
+      if you would like to join to talk about a story or a particular piece you
+      enjoyed or even hated.
     </p>
   </section>
 </MainLayout>
+
+<style>
+  p + p {
+    margin-block-start: theme("spacing.4");
+    text-indent: theme("spacing.5");
+  }
+  dl {
+    margin-block: calc(var(--spacing) * 8);
+    dt {
+      font-weight: var(--font-weight-bold);
+      font-size: var(--text-xl);
+      margin-block: calc(var(--spacing) * 4) calc(var(--spacing) * 2);
+      color: var(--color-primary-token);
+    }
+  }
+</style>


### PR DESCRIPTION
### TL;DR

Added cookie consent banner, PostHog analytics integration, and improved homepage content with styling updates.

### What changed?

- Added PostHog analytics integration with a new component
- Implemented a cookie consent banner that appears for first-time visitors
- Converted `add-blog.js` to TypeScript and updated the script to run with Deno
- Added a new npm script `new:blog` to create blog posts
- Enhanced the homepage with descriptive content about different types of writing
- Added styling for horizontal rules and improved layout grid definitions
- Updated text styling with proper indentation and spacing for paragraphs
- Added definition list styling for the content categories on the homepage

### How to test?

1. Run the site locally and verify the cookie consent banner appears on first visit
2. Check that accepting cookies sets the appropriate cookie and hides the banner
3. Try the new blog creation script with `npm run new:blog`
4. Verify PostHog analytics is loading correctly
5. Check the homepage layout and styling in both light and dark modes

### Why make this change?

These changes improve the user experience by providing transparency about analytics usage through the cookie consent banner. The PostHog integration enables error tracking without collecting personal information. The homepage content enhancements better explain the purpose of the site and the types of content visitors can expect to find. The script improvements make it easier to create new blog posts with a more robust TypeScript implementation.