### PR TITLE
chore: Updates the scripts shebang

### DIFF
--- a/scripts/add-blog.ts
+++ b/scripts/add-blog.ts
@@ -1,4 +1,5 @@
-#!/usr/env/bin -S deno run --allow-write
+#!/usr/bin/env -S deno run --allow-write --allow-read
+
 import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
@@ -8,10 +9,9 @@ type DatePartObject = Record<'year' | 'month' | 'day' | 'hour' | 'minute' | 'sec
 
 /**
  *
- * @param {Intl.DateTimeFormatPart[]} parts
+ * @param parts
  */
 function partsToObject(parts): DatePartObject {
-  /** @type {} */
   const obj = {} as DatePartObject;
   for (const part of parts) {
     if (part.type !== 'literal') {


### PR DESCRIPTION
### TL;DR

Fixed the shebang line in the add-blog.ts script and improved TypeScript typing.

### What changed?

- Corrected the shebang line from `#!/usr/env/bin -S deno run --allow-write` to `#!/usr/bin/env -S deno run --allow-write --allow-read`
- Added the `--allow-read` permission to the Deno execution command
- Removed unnecessary JSDoc type annotation for the `parts` parameter
- Removed a redundant comment `/** @type {} */` before the object declaration

### How to test?

1. Try executing the script directly from the command line: `./scripts/add-blog.ts`
2. Verify that the script runs without permission errors

### Why make this change?

The previous shebang line had an incorrect path to the environment executable, which would prevent the script from running properly when executed directly. Additionally, the script needed read permissions that weren't previously granted. The TypeScript typing improvements make the code cleaner and more maintainable.